### PR TITLE
ci(pre-commit): skip hooks requiring `just`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  # Skip hooks requiring `just` to be installed
+  skip: [codespell, fmt, clippy]
+
 repos:
   # General
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
The pre-commit CI doesn't have the `just` binary installed, so these tests consistently fail on the CI. Therefore, disable them on the CI.